### PR TITLE
fix: indicate every block as draft that is not mvp1

### DIFF
--- a/docs/.vuepress/theme/components/CFMMBlockPage.vue
+++ b/docs/.vuepress/theme/components/CFMMBlockPage.vue
@@ -137,8 +137,7 @@ const tools = computed(() =>
 );
 const underConstruction = computed(
   () =>
-    frontmatter.value.properties["redaction-state"] === undefined ||
-    frontmatter.value.properties["redaction-state"] === "Draft"
+    frontmatter.value.properties["redaction-state"] != "mvp1"
 );
 
 import { usePlausible } from "../plugins/plausible/client";


### PR DESCRIPTION
we had a status "partner is working on it" and those blocks did not show as
drafts, while they definitely should!