### PR TITLE
feat: disallow javascript access via robots.txt

### DIFF
--- a/docs/.vuepress/public/robots.txt
+++ b/docs/.vuepress/public/robots.txt
@@ -1,3 +1,4 @@
 User-agent: *
 Allow: /
 Disallow: /api/
+Disallow: /assets/*.js


### PR DESCRIPTION
this allows us to test the hypothesis that google uses up its
crawl budget for our CFMM website for crawling javascript
which changes a lot due to bundling. Some stats
- 62% of crawl requests are javascript
- google does not crawl some html pages, even though they have a recent
  lastmod date in sitemap.xml

We can deploy this change and observe google search console
for a week.