### PR TITLE
fix: journey stage and scope links on the block page were dead

### DIFF
--- a/docs/.vuepress/theme/components/CFMMBlockPage.vue
+++ b/docs/.vuepress/theme/components/CFMMBlockPage.vue
@@ -3,13 +3,13 @@
     <template #before>
       <div class="block-intro d-flex align-items-center">
         <router-link
-          :to="'/maturity-model/what-is-a-building-block#journey-stage'"
+          :to="'/understanding-cloud-foundation/what-is-a-building-block.html#journey-stage'"
         >
           <BlockJourneyStage
             :journey-stage="frontmatter.properties['journey-stage']"
           />
         </router-link>
-        <router-link :to="'/maturity-model/what-is-a-building-block#scope'">
+        <router-link :to="'/understanding-cloud-foundation/what-is-a-building-block.html#scope'">
           <BlockScope :scope="frontmatter.properties.scope" />
         </router-link>
         <span>{{ frontmatter.description }}</span>


### PR DESCRIPTION
they're not super well discoverable either, but nonetheless at least they are working again now