### PR TITLE
feat: select tool in cfmm via query param

### DIFF
--- a/docs/.vuepress/theme/components/embeddable-components/MaturityModel.vue
+++ b/docs/.vuepress/theme/components/embeddable-components/MaturityModel.vue
@@ -30,7 +30,8 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from "vue";
+import { computed, onMounted, ref } from "vue";
+import { useRoute } from 'vue-router';
 import { useCloudFoundationMaturityModel } from "../../plugins/cfmm/client";
 import { Pillar } from "../../plugins/cfmm/shared";
 import MaturityModelPillarBlocks from "../maturity-model/MaturityModelPillarBlocks.vue";
@@ -49,6 +50,14 @@ const pillars: Pillar[] = [
 let selectedTool = ref("");
 
 const toolSelectOptions = computed(() => cfmm.value.tools);
+
+onMounted(() => {
+  const selectedToolQueryParam = useRoute().query.selectedTool;
+  if (typeof selectedToolQueryParam === "string" && toolSelectOptions.value.includes(selectedToolQueryParam)) {
+    selectedTool.value = selectedToolQueryParam;
+  }
+});
+
 </script>
 
 <style scoped lang="scss">


### PR DESCRIPTION
By visiting a path like `/maturity-model/?selectedTool=meshStack`, the user will be shown the maturity model with the given tool selected. This is useful to advertise a tool in a blog post: we can include a link in the blog post which shows the user which parts of the CFMM are covered by this particular tool.