### PR TITLE
chore: increase bundle size

### DIFF
--- a/bundlesize.config.json
+++ b/bundlesize.config.json
@@ -2,7 +2,7 @@
   "files": [
     {
       "path": "docs/.vuepress/dist/assets/app.????????.js",
-      "maxSize": "355 kB",
+      "maxSize": "370 kB",
       "compression": "none",
       "description": "this is the app bundle that's always loaded and on the critical path. It includes the block index - extracting it could make it more lightweight."
     },


### PR DESCRIPTION
`yarn run docs:build` currently fails with the following message:

```
docs/.vuepress/dist/assets/app.0ef44b5f.js: 360.63KB > maxSize 355KB (no compression)
```

I guess the size has simply increased bit-by-bit with the last few commits.