### PR TITLE
feat: add slack community link

### DIFF
--- a/docs/.vuepress/config.ts
+++ b/docs/.vuepress/config.ts
@@ -41,6 +41,10 @@ navbar.push(
     link: "/understanding-cloud-foundation/",
   },
   {
+    text: "Maturity Model",
+    link: "/maturity-model/",
+  },
+    {
     text: "Pillars",
     children: [
       ...getChildDirectories("docs/maturity-model").map(
@@ -49,9 +53,9 @@ navbar.push(
     ],
   },
   {
-    text: "Maturity Model",
-    link: "/maturity-model/",
-  },
+    text: "Community",
+    link: "https://join.slack.com/t/cloudfoundation-org/shared_invite/zt-1na218t3p-CK~Ac~u8RZZRFtStVWFJQA",
+  }
 );
 
 // for the maturity model, each _page_ gets its own sidebar entry!


### PR DESCRIPTION
This is a super basic MVP of getting the invite link their ideally we'd have a proper landing page for the community that shows its benefits and why people should join.
However I couldn't get a nice-looking page going quickly from notion CMS. We probably have to hand-craft a page (like the Home.vue).